### PR TITLE
Fixes bug on climate_thresholds indexing

### DIFF
--- a/src/03_fit_climate_model.R
+++ b/src/03_fit_climate_model.R
@@ -981,7 +981,7 @@ with_progress({
           mtp_text <- paste0(probs*100,"pct")
           
           #Get threshold value and apply to consensus predictions
-          threshold<-climate_thresholds[[mtp_text]]
+          threshold<-climate_thresholds[[mtp_label]]
           binary_map_future <- future_consensus_median  >= threshold
           binary_map_future <- as.factor( binary_map_future*1) #Convert TRUE/FALSE to 1/0 and then to Present/Absent
           levels( binary_map_future) <- data.frame(ID = c(0, 1),


### PR DESCRIPTION
Fixes a bug on 03_climate_model.R – error message:
> "Progress interrupted by simpleError condition: comparison (>=) is possible only for atomic and list types
> Error in future_consensus_median >= threshold : 
>  comparison (>=) is possible only for atomic and list types"

 threshold is NULL and hence the binarized predictions cannot be generated
> threshold
NULL

 This issue is due to fault indexing on:
> climate_thresholds[[mtp_text]]
NULL
> mtp_text
[1] "1pct"

 Where the name indices on climate_thresholds are:
> climate_thresholds
$\`1%\`
[1] 0.1199698
$\`5%\`
[1] 0.316536

 Simply shifting the name index on climate_thresholds from mtp_text to mtp_label solves the issue:
> climate_thresholds[[mtp_label]]
[1] 0.1199698