### PR TITLE
Support custom Europe boundary layers

### DIFF
--- a/src/00_configurations.R
+++ b/src/00_configurations.R
@@ -11,6 +11,8 @@ pseudoabsence_thinning_method <- "kmeans_clustering" #either "random" or "kmeans
 
 mtp_probabilities <- c(0.01, 0.05) #Define MTP thresholds (0.01 = 1%; 0.05 = 5%,...)
 
+custom_eu_boundary_path <- NULL  #either NULL or a path to a custom Europe boundary vector layer
+
 custom_country_boundary_path <- NULL  #either NULL or a path to a shapefile, if not NULL this overwrites country_of_interest
 
 country_of_interest <- "Europe"

--- a/src/01_prepare_files_and_folders.R
+++ b/src/01_prepare_files_and_folders.R
@@ -378,13 +378,14 @@ if (!use_user_specific_climate) {
   #--------------------------------------------
   #----------- Load boundary layers -----------
   #--------------------------------------------
-  euboundary <- terra::rast(file.path("data", "external", "habitat", "Agriculture.tif"))%>%
-    terra::project(globalclimpreds_terra[[1]])%>%
-    terra::crop(terra::ext(-38, 50,  24.29152732065, 72.66652712715))
+  euboundary <- load_climate_eu_boundary(
+    custom_path = custom_eu_boundary_path,
+    reference = globalclimpreds_terra[[1]]
+  )
   
   if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
     country_boundary<-sf::read_sf(here::here("data","external","GIS","Country","country.shp"))%>%
-      sf::st_transform(crs=4326)%>%
+      sf::st_transform(crs(globalclimpreds_terra[[1]]))%>%
       terra::vect()
   }else{
     country_boundary<-euboundary
@@ -518,10 +519,7 @@ terra::writeRaster(habitat_stack,
 #---------------------------------------------
 #----- Create an EU boundary shapefile -------
 #---------------------------------------------
-euboundary <- terra::rast(file.path("data", "external", "habitat", "Agriculture.tif"))
-euboundary<-(euboundary*0+1)
-euboundary <- terra::as.polygons(euboundary, dissolve = TRUE)  # merge adjacent cells
-euboundary <- sf::st_as_sf(euboundary)  # convert to sf
+euboundary <- create_default_eu_boundary()
 euboundary_path<-file.path("data", "external", "GIS", "Europe")
 if(!dir.exists(euboundary_path)) dir.create(euboundary_path)
 sf::write_sf(euboundary, file.path(euboundary_path, "EUboundary.shp"))

--- a/src/03_fit_climate_model.R
+++ b/src/03_fit_climate_model.R
@@ -103,8 +103,10 @@ predictor_sf_crs <- sf::st_crs(predictor_crs)
 #--------------------------------------------
 #----------- Load boundary layers -----------
 #--------------------------------------------
-euboundary <- sf::st_read(file.path("data", "external", "GIS", "Europe", "EUboundary.shp"), quiet = TRUE) %>%
-  sf::st_transform(predictor_sf_crs) %>%
+euboundary <- load_eu_boundary(
+  custom_path = custom_eu_boundary_path,
+  reference = current_climate_reference
+) %>%
   terra::vect()
 
 if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){

--- a/src/04_fit_habitat_model.R
+++ b/src/04_fit_habitat_model.R
@@ -30,16 +30,18 @@ habitatstack_file <- file.path(processed_folder, "habitat_stack.tif")
 
 
 #--------------------------------------------
+habitat_stack<-terra::rast(habitatstack_file)
 #---------   Load euboundary  ---------
 #--------------------------------------------
-euboundary_path<-file.path("data", "external", "GIS", "Europe", "EUboundary.shp")
-euboundary<-sf::st_read(euboundary_path)
+euboundary <- load_eu_boundary(
+  custom_path = custom_eu_boundary_path,
+  reference = habitat_stack[[1]]
+)
 
 
 #---------------------------------------------
 #----- Load country boundary ------
 #---------------------------------------------
-habitat_stack<-terra::rast(habitatstack_file)
 if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
   country_boundary <- sf::read_sf(here::here("data","external","GIS","Country","country.shp"))%>%
     sf::st_transform(crs(habitat_stack[[1]]))%>%

--- a/src/05_cross_validation.R
+++ b/src/05_cross_validation.R
@@ -58,22 +58,37 @@ accepted_taxonkeys <- unique(taxa_info$acceptedTaxonKey)
 
 
 #--------------------------------------------
-#------------ Load euboundary  --------------
-#--------------------------------------------
-euboundary_path<-file.path("data", "external", "GIS", "Europe", "EUboundary.shp")
-euboundary<-sf::st_read(euboundary_path)
-euboundary_wgs84<-euboundary%>%
-  sf::st_transform(crs = 4326)
-
-
-#--------------------------------------------
 #-----------------Load rasters---------------
 #--------------------------------------------
 #Load rasters 
 climate_stack <- terra::rast(climate_path)
 habitat_stack <- terra::rast(habitat_path)
-eu_climate_stack<- terra::rast(eu_climpreds_path)%>%
-  terra::project(habitat_stack[[1]])
+
+
+#--------------------------------------------
+#------------ Load euboundary  --------------
+#--------------------------------------------
+euboundary <- load_eu_boundary(
+  custom_path = custom_eu_boundary_path,
+  reference = habitat_stack[[1]]
+)
+euboundary_vect <- terra::vect(euboundary)
+
+if (is.null(custom_eu_boundary_path)) {
+  eu_climate_stack <- terra::rast(eu_climpreds_path) %>%
+    terra::project(habitat_stack[[1]])
+  
+  eu_sampling_mask <- habitat_stack[[1]]
+} else {
+  eu_climate_stack <- terra::rast(eu_climpreds_path) %>%
+    terra::project(habitat_stack[[1]]) %>%
+    terra::crop(euboundary_vect) %>%
+    terra::mask(euboundary_vect)
+  
+  eu_sampling_mask <- habitat_stack[[1]] %>%
+    terra::crop(euboundary_vect) %>%
+    terra::mask(euboundary_vect)
+}
 
 
 #-----------------------------------------------------------
@@ -82,7 +97,7 @@ eu_climate_stack<- terra::rast(eu_climpreds_path)%>%
 #Extract a subsample of European pixels for Boyce calculation 
 set.seed(728)
 eu_subsample <- terra::spatSample(
-  habitat_stack[[1]],
+  eu_sampling_mask,
   size = boyce_background_size, 
   method = "random", 
   na.rm = TRUE, #Ignore NA pixels
@@ -167,6 +182,8 @@ for (i in seq_along(accepted_taxonkeys)) {
   top5_methods  <- climatemodel$top5_models
   global_presabs <- climatemodel$global_presabs
   climate_predictors <- climatemodel$selected_predictors
+  euboundary_occurrence <- euboundary %>%
+    sf::st_transform(crs = sf::st_crs(global_presabs))
   rm(climatemodel)
   
   
@@ -175,7 +192,7 @@ for (i in seq_along(accepted_taxonkeys)) {
   #--------------------------------------------------
   eu_occ <- global_presabs%>%
     dplyr::filter(species==1)%>%
-    sf::st_filter(euboundary_wgs84) 
+    sf::st_filter(euboundary_occurrence) 
   
   #Only validate climate model in Europe if 40 or more occs 
   eu_climate_validation <- nrow(eu_occ) >= 40
@@ -444,7 +461,7 @@ for (i in seq_along(accepted_taxonkeys)) {
       #Extract data for validation in Europe
       if(eu_climate_validation){
         eu_test_data  <- test_data%>%
-          sf::st_filter(euboundary_wgs84)
+          sf::st_filter(euboundary_occurrence)
         
         eu_env<-extract_env(eu_test_data, climate_selection)
         datasets$eu_occ_env <- eu_env$presences
@@ -558,7 +575,7 @@ for (i in seq_along(accepted_taxonkeys)) {
       #Extract data for validation in Europe
       if(eu_climate_validation){
         euboundary_presabs  <- global_presabs%>%
-          sf::st_filter(euboundary_wgs84)
+          sf::st_filter(euboundary_occurrence)
         
         eu_env<-extract_env(euboundary_presabs, climate_selection)
         datasets$eu_occ_env <- eu_env$presences

--- a/src/helper_functions.R
+++ b/src/helper_functions.R
@@ -958,6 +958,165 @@ resolve_input_path <- function(path, base_dir = getwd()) {
 
 
 #-----------------------------------------------------------------
+#--Return an sf CRS from a supported reference object-------------
+#-----------------------------------------------------------------
+get_reference_crs <- function(reference) {
+  if (inherits(reference, "SpatRaster") || inherits(reference, "SpatVector")) {
+    reference_crs <- terra::crs(reference)
+    if (!nzchar(reference_crs)) {
+      stop("The reference raster/vector does not have a defined CRS.", call. = FALSE)
+    }
+    return(sf::st_crs(reference_crs))
+  }
+  
+  if (inherits(reference, "sf") || inherits(reference, "sfc")) {
+    reference_crs <- sf::st_crs(reference)
+    if (is.na(reference_crs)) {
+      stop("The reference vector does not have a defined CRS.", call. = FALSE)
+    }
+    return(reference_crs)
+  }
+  
+  if (inherits(reference, "crs")) {
+    if (is.na(reference)) {
+      stop("The reference CRS is not defined.", call. = FALSE)
+    }
+    return(reference)
+  }
+  
+  if ((is.character(reference) || is.numeric(reference)) && length(reference) == 1) {
+    reference_crs <- sf::st_crs(reference)
+    if (is.na(reference_crs)) {
+      stop("The reference CRS could not be parsed.", call. = FALSE)
+    }
+    return(reference_crs)
+  }
+  
+  stop("Unsupported reference object supplied for CRS matching.", call. = FALSE)
+}
+
+
+#-----------------------------------------------------------------
+#--Create the default EU boundary from the habitat raster---------
+#-----------------------------------------------------------------
+create_default_eu_boundary <- function(habitat_boundary_raster = file.path("data", "external", "habitat", "Agriculture.tif")) {
+  habitat_boundary_raster <- resolve_input_path(habitat_boundary_raster)
+  
+  if (!file.exists(habitat_boundary_raster)) {
+    stop("The habitat raster used to derive the default EU boundary does not exist: ", habitat_boundary_raster, call. = FALSE)
+  }
+  
+  euboundary <- terra::rast(habitat_boundary_raster)
+  euboundary <- (euboundary * 0) + 1
+  euboundary <- terra::as.polygons(euboundary, dissolve = TRUE)
+  euboundary <- sf::st_as_sf(euboundary)
+  
+  if (!all(sf::st_is_valid(euboundary))) {
+    euboundary <- suppressWarnings(sf::st_make_valid(euboundary))
+  }
+  
+  euboundary
+}
+
+
+#-----------------------------------------------------------------
+#--Load the climate masking layer while preserving legacy default--
+#-----------------------------------------------------------------
+load_climate_eu_boundary <- function(custom_path = NULL,
+                                     reference,
+                                     habitat_boundary_raster = file.path("data", "external", "habitat", "Agriculture.tif"),
+                                     legacy_extent = c(-38, 50, 24.29152732065, 72.66652712715)) {
+  if (missing(reference) || is.null(reference)) {
+    stop("A reference raster must be supplied to derive the climate EU boundary.", call. = FALSE)
+  }
+  
+  if (is.null(custom_path)) {
+    habitat_boundary_raster <- resolve_input_path(habitat_boundary_raster)
+    
+    if (!file.exists(habitat_boundary_raster)) {
+      stop("The habitat raster used to derive the default climate EU boundary does not exist: ", habitat_boundary_raster, call. = FALSE)
+    }
+    
+    return(
+      terra::rast(habitat_boundary_raster) %>%
+        terra::project(reference) %>%
+        terra::crop(terra::ext(legacy_extent[1], legacy_extent[2], legacy_extent[3], legacy_extent[4]))
+    )
+  }
+  
+  load_eu_boundary(
+    custom_path = custom_path,
+    reference = reference,
+    habitat_boundary_raster = habitat_boundary_raster
+  ) %>%
+    terra::vect()
+}
+
+
+#-----------------------------------------------------------------
+#--Load the active EU boundary and align it to a reference CRS----
+#-----------------------------------------------------------------
+load_eu_boundary <- function(custom_path = NULL,
+                             reference = NULL,
+                             default_path = file.path("data", "external", "GIS", "Europe", "EUboundary.shp"),
+                             habitat_boundary_raster = file.path("data", "external", "habitat", "Agriculture.tif")) {
+  if (is.null(custom_path)) {
+    default_path <- resolve_input_path(default_path)
+    
+    if (file.exists(default_path)) {
+      euboundary <- sf::st_read(default_path, quiet = TRUE)
+    } else {
+      euboundary <- create_default_eu_boundary(habitat_boundary_raster)
+    }
+  } else {
+    custom_path <- resolve_input_path(custom_path)
+    
+    if (!file.exists(custom_path)) {
+      stop("The file provided in 'custom_eu_boundary_path' does not exist: ", custom_path, call. = FALSE)
+    }
+    
+    euboundary <- sf::st_read(custom_path, quiet = TRUE)
+  }
+  
+  if (nrow(euboundary) == 0) {
+    stop("The EU boundary layer does not contain any features.", call. = FALSE)
+  }
+  
+  empty_features <- sf::st_is_empty(euboundary)
+  if (any(empty_features)) {
+    euboundary <- euboundary[!empty_features, , drop = FALSE]
+  }
+  
+  if (nrow(euboundary) == 0) {
+    stop("The EU boundary layer only contains empty geometries.", call. = FALSE)
+  }
+  
+  if (!all(sf::st_is_valid(euboundary))) {
+    euboundary <- suppressWarnings(sf::st_make_valid(euboundary))
+  }
+  
+  boundary_crs <- sf::st_crs(euboundary)
+  if (is.na(boundary_crs)) {
+    stop("The EU boundary layer must have a defined CRS.", call. = FALSE)
+  }
+  
+  if (!is.null(reference)) {
+    reference_crs <- get_reference_crs(reference)
+    
+    if (!isTRUE(boundary_crs == reference_crs)) {
+      euboundary <- sf::st_transform(euboundary, reference_crs)
+    }
+    
+    if (!isTRUE(sf::st_crs(euboundary) == reference_crs)) {
+      stop("The EU boundary layer CRS could not be aligned to the reference raster/vector CRS.", call. = FALSE)
+    }
+  }
+  
+  euboundary
+}
+
+
+#-----------------------------------------------------------------
 #--Load a named raster stack from manifest rows--------------------
 #-----------------------------------------------------------------
 load_named_raster_stack <- function(stack_rows) {


### PR DESCRIPTION

Adds an optional custom Europe boundary input so climate, habitat, and validation steps can use a project-specific European modeling extent provided as a vector file that terra/vect can handle.

**Summary:**
- Adds custom_eu_boundary_path to the config file.
- Centralizes EU boundary loading/creation in helper functions.
- Aligns custom/default EU boundaries to the active raster CRS (if needed, if CRS differs).
- Applies the active boundary in file preparation, climate modeling, habitat modeling, and cross-validation.
- Employs CRS handling for default versus custom boundaries.
- Evaluates whether legacy default Europe behavior is preserved when custom_eu_boundary_path <- NULL.
- Applies boundary masking/cropping behavior in cross-validation.

**Things to consider:**
- This configuration enables the workflow to run for virtually any region worldwide when combined with user-defined global data, while keeping the default workflow unchanged.

- As a follow-up, perhaps in the future it would make sense to refactor some naming conventions and generalize certain config parameters to better support this increased flexibility.


