### PR TITLE
Validate and preserve manifest raster stack names

### DIFF
--- a/src/helper_functions.R
+++ b/src/helper_functions.R
@@ -1120,8 +1120,41 @@ load_eu_boundary <- function(custom_path = NULL,
 #--Load a named raster stack from manifest rows--------------------
 #-----------------------------------------------------------------
 load_named_raster_stack <- function(stack_rows) {
+  required_cols <- c("var_name", "file_path")
+  missing_cols <- setdiff(required_cols, names(stack_rows))
+  
+  if (length(missing_cols) > 0) {
+    stop(
+      "The raster stack rows are missing required columns: ",
+      paste(missing_cols, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  
+  if (nrow(stack_rows) == 0) {
+    stop("No raster rows were supplied to build the climate stack.", call. = FALSE)
+  }
+  
+  if (anyDuplicated(stack_rows$var_name)) {
+    stop("The raster stack rows contain duplicated 'var_name' values.", call. = FALSE)
+  }
+  
   stack <- terra::rast(stack_rows$file_path)
-  names(stack) <- stack_rows$var_name
+  
+  if (terra::nlyr(stack) != nrow(stack_rows)) {
+    stop(
+      "The number of raster layers loaded does not match the number of manifest rows provided.",
+      call. = FALSE
+    )
+  }
+  
+  expected_names <- as.character(stack_rows$var_name)
+  names(stack) <- expected_names
+  
+  if (!identical(names(stack), expected_names)) {
+    stop("The climate raster stack could not be named exactly as specified in 'var_name'.", call. = FALSE)
+  }
+  
   stack
 }
 


### PR DESCRIPTION

Improves raster stack loading from CSV manifest rows by making predictor names deterministic and adding validation.


**Summary:**
- Checks that manifest rows include var_name and file_path.
- Rejects empty or duplicated raster stack definitions.
- Verifies the loaded raster layer count matches the manifest row count.
- Assigns and confirms exact predictor names from var_name.
- Generate error messages for malformed manifests.
- Checks whether this validation catches the expected bad-input cases without changing valid workflows.

**Notes:**
- This assumes that raster stacks are built from one-to-one, single-band rasters, which means each raster file must contain exactly one predictor. This is to facilitate data reading and stack construction via terra.