### PR TITLE
Use custom climate metadata in habitat modelling and cross-validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ data/external/GIS/Belgium_ecoregions/
 data/external/habitat/
 data/projects/
 .renviron
+
+.positai
+
+data/external/gadm/
+data/external/file_paths_custom_data.csv

--- a/src/02_global_occurrence_download.R
+++ b/src/02_global_occurrence_download.R
@@ -1,7 +1,8 @@
 #--------------------------------------------
 #-----------------Load packages--------------
 #--------------------------------------------
-packages <- c("rgbif", "dplyr", "purrr", "assertthat", "readr", "here", "retry", "CoordinateCleaner", "remotes", "stringr")
+packages <- c("rgbif", "dplyr", "purrr", "assertthat", "readr", "here", "retry", 
+              "CoordinateCleaner", "remotes", "stringr")
 
 installed_packages <- installed.packages() |>
   as.data.frame()

--- a/src/03_fit_climate_model.R
+++ b/src/03_fit_climate_model.R
@@ -58,6 +58,7 @@ climate_input_mode <- if (use_user_specific_climate) "user_specific" else "chels
 processed_folder <- file.path("data", "external", "climate", "chelsa_current","processed")
 
 if (use_user_specific_climate) {
+  
   climate_manifest <- load_user_specific_climate_manifest(user_specific_climate_data)
   climate_manifest_path <- climate_manifest$manifest_path
   future_paths <- climate_manifest$future_rows
@@ -66,12 +67,15 @@ if (use_user_specific_climate) {
   globalclimpreds_5k_file <- NULL
   eu_climpreds_file <- NULL
   country_climpreds_file <- NULL
+  
 } else {
+  
   climate_manifest <- NULL
   climate_manifest_path <- NULL
   globalclimpreds_file <- file.path(processed_folder, "globalclimpreds.tif")
   globalclimpreds_5k_file <- file.path(processed_folder,"globalclim_5k.tif")
   eu_climpreds_file <- file.path(processed_folder,"euclimpreds.tif")
+  
   if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
     country_climpreds_file <- file.path(processed_folder, "country_climpreds.tif")
   }else{
@@ -158,16 +162,16 @@ gc()
 #-------Start loop for SDM modelling --------
 #--------------------------------------------
 
-with_progress({
-  p <- progressr::progressor(along = 1:length(split_df))
-  
+# with_progress({
+#   p <- progressr::progressor(along = 1:length(split_df))
+#   
   
   for(i in 1:length(split_df)) {
     
     #--------------------------------------------
     #------------- Track progress ---------------
     #--------------------------------------------
-    p()
+    # p()
     
     #--------------------------------------------
     #----------- Load species details -----------
@@ -478,7 +482,7 @@ with_progress({
     
     #Select 10000 pseudoabsences
     if(pseudoabsence_thinning_method == "random"){
-      print("Thinning pseudoabsences randomly")
+      message("Thinning pseudoabsences randomly")
       set.seed(101) 
       global_points <- global_points[sample(nrow(global_points), 10000, replace=FALSE), ]%>%
         sf::st_as_sf()
@@ -491,7 +495,7 @@ with_progress({
         dplyr::select(decimalLongitude, decimalLatitude, geometry)
       
     }else if (pseudoabsence_thinning_method == "kmeans_clustering"){
-      print("Thinning pseudoabsences based on k-means clustering")
+      message("Thinning pseudoabsences based on k-means clustering")
       
       #Extract environmental data from filtered pseudoabsences
       pa_climate_data <- terra::extract(globalclimpreds_terra, global_points, ID = FALSE, xy = TRUE)
@@ -605,7 +609,36 @@ with_progress({
     selected_predictor_names <- names(globalclimpreds_terra_selection)
     
     if (use_user_specific_climate) {
-      current_prediction_selection <- globalclimpreds_terra_selection
+      
+      # Crop and mask scaled_stack to European extent
+      # Write to disk 
+
+      eu_climpreds_file <- file.path(processed_folder,"euclimpreds.tif")
+      
+      if(!file.exists(eu_climpreds_file)){
+        
+        message("Cropping global data to European extent for prediction")
+        
+        eu_climpreds.10 <- crop(
+          globalclimpreds_terra, 
+          euboundary, 
+          mask      = TRUE, 
+          snap      = "near", 
+          filename  = file.path(processed_folder,"euclimpreds.tif"), 
+          overwrite = TRUE
+        )
+        #Clean up
+        rm(eu_climpreds.10)
+      }else{
+        message("European extent data for prediction already exists")
+        
+      }
+    
+      #Reload
+      eu_climpreds.10 <- terra::rast(eu_climpreds_file)
+      current_prediction_selection <- eu_climpreds.10 %>%
+        subset(!names(eu_climpreds.10) %in% highlyCorrelated)
+      
     } else {
       eu_climpreds.10 <- terra::rast(eu_climpreds_file)
       current_prediction_selection <- eu_climpreds.10 %>%
@@ -655,13 +688,17 @@ with_progress({
       
       pred_raster <- try({
         
+        blk<-0
         for(rasterblock in seq_along(exts)) {
+          
+          blk<-blk+1
           block_r <- crop(current_prediction_selection, exts[[rasterblock]])
           
           # Make predictions for each block
           pred_blocks[[rasterblock]] <- predict(model,
                                                 newdata = block_r,
                                                 method = modelmethod)
+          message("Finished predicting block ", blk, " out of ", nblocks)
         }
         
         # Merge blocks only if all succeed
@@ -765,6 +802,7 @@ with_progress({
     
     #Step 9: Create country_level layers if relevant
     if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
+      
       ensemble_suitability<- consensus_median%>%
         terra::crop(country_boundary)%>%
         terra::mask(country_boundary)
@@ -776,19 +814,23 @@ with_progress({
       ensemble_mean<- consensus_mean%>%
         terra::crop(country_boundary)%>%
         terra::mask(country_boundary)
-    }else if (use_user_specific_climate){
-      ensemble_suitability <- consensus_median %>%
-        terra::crop(euboundary) %>%
-        terra::mask(euboundary)
       
-      ensemble_sd <- consensus_sd %>%
-        terra::crop(euboundary) %>%
-        terra::mask(euboundary)
+    # }else if (use_user_specific_climate){
+    #   
+    #   ensemble_suitability <- consensus_median %>%
+    #     terra::crop(euboundary) %>%
+    #     terra::mask(euboundary)
+    #   
+    #   ensemble_sd <- consensus_sd %>%
+    #     terra::crop(euboundary) %>%
+    #     terra::mask(euboundary)
+    #   
+    #   ensemble_mean <- consensus_mean %>%
+    #     terra::crop(euboundary) %>%
+    #     terra::mask(euboundary)
       
-      ensemble_mean <- consensus_mean %>%
-        terra::crop(euboundary) %>%
-        terra::mask(euboundary)
     }else{
+      
       ensemble_suitability<-consensus_median
       ensemble_sd <- consensus_sd
       ensemble_mean<-consensus_mean
@@ -954,8 +996,9 @@ with_progress({
           
           pred_raster_future  <- try({
             
+            blk<-0
             for(rasterblock in seq_along(exts)) {
-              
+              blk<-blk+1
               #Crop climate rasters into one of the 4 latitudinal rasterblocks
               block_r <- crop(future_selection, exts[[rasterblock]])
               
@@ -963,6 +1006,7 @@ with_progress({
               pred_blocks[[rasterblock]] <- predict(model,
                                                     newdata = block_r,
                                                     method = modelmethod)
+              message("Finished predicting block ", blk, " out of ", nblocks)
             }
             
             # Merge blocks only if all succeed
@@ -1229,7 +1273,7 @@ with_progress({
     terra::tmpFiles(remove = TRUE)
     
   }
-})
+# })
 
 
 #--------------------------------------------

--- a/src/03_fit_climate_model.R
+++ b/src/03_fit_climate_model.R
@@ -1,7 +1,12 @@
 #--------------------------------------------
 #-------------- Load packages ---------------
 #--------------------------------------------
-packages <- c( "dplyr", "stringr", "here", "qs","CoordinateCleaner", "raster", "rnaturalearth", "rnaturalearthdata", "ggplot2","tidyterra", "dismo", "sdm", "caret", "viridisLite", "kableExtra","future", "future.apply","randomForest","earth", "progressr", "sf", "gbm", "PresenceAbsence","geosphere","arm", "RStoolbox", "ecospat", "viridis", "patchwork", "grid", "purrr", "magick", "terra")
+packages <- c( "dplyr", "stringr", "here", "qs","CoordinateCleaner", "raster", 
+               "rnaturalearth", "rnaturalearthdata", "ggplot2","tidyterra", 
+               "dismo", "sdm", "caret", "viridisLite", "kableExtra","future", 
+               "future.apply","randomForest","earth", "progressr", "sf", "gbm", 
+               "PresenceAbsence","geosphere","arm", "RStoolbox", "ecospat", 
+               "viridis", "patchwork", "grid", "purrr", "magick", "terra")
 
 for(package in packages) {
   print(package)
@@ -56,6 +61,9 @@ rm(cleaned)
 use_user_specific_climate <- !is.null(user_specific_climate_data)
 climate_input_mode <- if (use_user_specific_climate) "user_specific" else "chelsa"
 processed_folder <- file.path("data", "external", "climate", "chelsa_current","processed")
+if (!dir.exists(processed_folder)) {
+  dir.create(processed_folder, recursive = TRUE, showWarnings = FALSE)
+}
 
 if (use_user_specific_climate) {
   
@@ -372,7 +380,9 @@ gc()
     #-Don't fit model if less than 20 global presences -----
     #-------------------------------------------------------   
     if(nrow(global.occ.sf)<20){
-      warning(paste0("Skipping species ", species, " because the number of occurrences is less than 20 (n =",nrow(global.occ.sf),")"))
+      warning(paste0("Skipping species ", species, 
+                     " because the number of occurrences is less than 20 (n =",
+                     nrow(global.occ.sf),")"))
       next  # Skip the rest of the loop and move to the next iteration
     }
     

--- a/src/04_fit_habitat_model.R
+++ b/src/04_fit_habitat_model.R
@@ -131,6 +131,43 @@ with_progress({
       
       #This was stored as part of  script 02_fit_global_model
       globalmodels <- qs::qread(global_model_file)
+      climate_input_mode_saved <- globalmodels$climate_input_mode
+      if (is.null(climate_input_mode_saved) || !nzchar(climate_input_mode_saved)) {
+        climate_input_mode_saved <- "chelsa"
+      }
+      climate_manifest_path_saved <- globalmodels$climate_manifest_path
+      predictor_crs_saved <- globalmodels$predictor_crs
+      
+      if (!climate_input_mode_saved %in% c("chelsa", "user_specific")) {
+        stop(
+          "Unsupported climate input mode stored in ",
+          basename(global_model_file),
+          ": ",
+          climate_input_mode_saved,
+          call. = FALSE
+        )
+      }
+      
+      if (climate_input_mode_saved == "user_specific") {
+        if (is.null(climate_manifest_path_saved) || !nzchar(climate_manifest_path_saved)) {
+          stop(
+            "The saved climate model metadata is missing 'climate_manifest_path'. Rerun 03_fit_climate_model.R for ",
+            speciesName,
+            ".",
+            call. = FALSE
+          )
+        }
+        
+        if (is.null(predictor_crs_saved) || !nzchar(predictor_crs_saved)) {
+          stop(
+            "The saved climate model metadata is missing 'predictor_crs'. Rerun 03_fit_climate_model.R for ",
+            speciesName,
+            ".",
+            call. = FALSE
+          )
+        }
+      }
+      use_user_specific_climate_saved <- climate_input_mode_saved == "user_specific"
       
       #Extract different data objects stored in globalmodels
       global.occ.sf <- globalmodels$occurrences1km %>% # FULL occurrence with coordinateUncertainty <= 1km
@@ -862,18 +899,31 @@ with_progress({
     #------------------------------------------------------------    
     #-- Create final predictions combining habitat and climate --
     #------------------------------------------------------------
-    if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
-      consensus_climate<-terra::rast(file.path( climate_raster_folder,
-                                                paste0(speciesName, "_Climate_current_ensemble_Europe.tif")))%>%
-        terra::project(consensus_habitat)
+    current_climate_file <- if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
+      file.path(climate_raster_folder, paste0(speciesName, "_Climate_current_ensemble_Europe.tif"))
     }else{
-      consensus_climate<-terra::rast( file.path(climate_raster_folder,
-                                                paste0(speciesName,"_Climate_current_ensemble.tif")))%>%
+      file.path(climate_raster_folder, paste0(speciesName,"_Climate_current_ensemble.tif"))
+    }
+    
+    if (use_user_specific_climate_saved) {
+      consensus_climate <- terra::rast(current_climate_file)
+      combined_habitat_suitability <- align_continuous_raster(consensus_habitat, consensus_climate)
+      combined_occ_current <- sf::st_transform(eu_occ, crs = sf::st_crs(terra::crs(consensus_climate)))
+      current_country_boundary <- if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
+        terra::project(country_boundary, terra::crs(consensus_climate))
+      }else{
+        country_boundary
+      }
+    } else {
+      consensus_climate <- terra::rast(current_climate_file) %>%
         terra::project(consensus_habitat)
+      combined_habitat_suitability <- consensus_habitat
+      combined_occ_current <- eu_occ
+      current_country_boundary <- country_boundary
     }
     
     #Combine suitability predictions by global model (climate) and EU habitat model
-    clim_hab <- sqrt(consensus_habitat * consensus_climate)
+    clim_hab <- sqrt(combined_habitat_suitability * consensus_climate)
     
     
     #--------------------------------------------------
@@ -882,8 +932,8 @@ with_progress({
     # Crop to extent of country if relevant
     if(tolower(country_of_interest)!="europe"||!is.null(custom_country_boundary_path)){
       ensemble_combined_suitability<- clim_hab%>%
-        terra::crop(country_boundary)%>%
-        terra::mask(country_boundary)
+        terra::crop(current_country_boundary)%>%
+        terra::mask(current_country_boundary)
     }else{
       ensemble_combined_suitability<-clim_hab
     }
@@ -898,7 +948,7 @@ with_progress({
     terra::writeRaster(ensemble_combined_suitability, filename = clim_hab_file, overwrite = T)
     
     #Export PDFs with and without occurrences plotted
-    for (occs in list(NULL, eu_occ)){
+    for (occs in list(NULL, combined_occ_current)){
       filename <- ifelse(is.null(occs), base_file, paste0(base_file, "_occ"))
       
       exportPDF(predictions = ensemble_combined_suitability,
@@ -926,23 +976,30 @@ with_progress({
     consensus_climate_mean <- terra::rast(mean_climate_path)
     consensus_climate_sd <- terra::rast(sd_climate_path)
     
-    #reproject mean climate to mean habitat crs
-    consensus_climate_mean <- terra::project(consensus_climate_mean,
+    if (use_user_specific_climate_saved) {
+      combined_habitat_mean <- align_continuous_raster(ensemble_habitat_mean, consensus_climate_mean)
+      combined_habitat_sd <- align_continuous_raster(ensemble_habitat_sd, consensus_climate_mean)
+    } else {
+      #reproject mean climate to mean habitat crs
+      consensus_climate_mean <- terra::project(consensus_climate_mean,
+                                               ensemble_habitat_mean,
+                                               method = "bilinear")
+      consensus_climate_sd <- terra::project(consensus_climate_sd,
                                              ensemble_habitat_mean,
                                              method = "bilinear")
-    consensus_climate_sd <- terra::project(consensus_climate_sd,
-                                           ensemble_habitat_mean,
-                                           method = "bilinear")
+      combined_habitat_mean <- ensemble_habitat_mean
+      combined_habitat_sd <- ensemble_habitat_sd
+    }
     
     # small floor to avoid division by zero
     eps <- 1e-6    
     
     # compute geometric mean
-    S <- sqrt(consensus_climate_mean * ensemble_habitat_mean)
+    S <- sqrt(consensus_climate_mean * combined_habitat_mean)
     
     # compute relative SDs 
     sd_climate <- consensus_climate_sd / (consensus_climate_mean + eps)
-    sd_habitat <- ensemble_habitat_sd / (ensemble_habitat_mean + eps)
+    sd_habitat <- combined_habitat_sd / (combined_habitat_mean + eps)
     
     # combined relative uncertainty 
     sd_comb <- sqrt(sd_climate^2 + sd_habitat^2)
@@ -978,7 +1035,7 @@ with_progress({
     #------------ Create binary map -----------
     #------------------------------------------
     # Get predicted values at occurrence points
-    vals_occ <- terra::extract(clim_hab, terra::vect(eu_occ), ID=FALSE)
+    vals_occ <- terra::extract(clim_hab, terra::vect(combined_occ_current), ID=FALSE)
     
     # Create binary maps
     for (probs in mtp_probabilities){
@@ -1005,7 +1062,7 @@ with_progress({
       
       # export as PDF and PNG with and without occurrences plotted 
       base_file<- paste0(combined_basefile, "current_binary",mtp_value,"pct")
-      for (occs in list(NULL, eu_occ)){
+      for (occs in list(NULL, combined_occ_current)){
         filename <- ifelse(is.null(occs), base_file, paste0(base_file, "_occ"))
         exportPDF(predictions = binary_map_pct,
                   dataType = "Binary",
@@ -1041,11 +1098,20 @@ with_progress({
         #Get climate data for specific period and scenario
         future_folder <- file.path(base_dir, "Climate", period, scenario, "Predictions", "Rasters")
         ensemble_file <- file.path(future_folder, paste0(global_basefile, period,"_",scenario,"_ensemble.tif"))
-        future_climate <- terra::rast(ensemble_file)%>%
-          terra::project(ensemble_habitat_suitability)
+        future_climate <- terra::rast(ensemble_file)
+        
+        if (use_user_specific_climate_saved) {
+          future_habitat_suitability <- align_continuous_raster(ensemble_habitat_suitability, future_climate)
+          future_occ <- sf::st_transform(eu_occ, crs = sf::st_crs(terra::crs(future_climate)))
+        } else {
+          future_climate <- future_climate %>%
+            terra::project(ensemble_habitat_suitability)
+          future_habitat_suitability <- ensemble_habitat_suitability
+          future_occ <- eu_occ
+        }
         
         #Final ensemble predictions
-        final_ensemble<-sqrt(ensemble_habitat_suitability * future_climate)
+        final_ensemble<-sqrt(future_habitat_suitability * future_climate)
         
         # Export future ensemble raster (favorability) 
         future_folder <- file.path(base_dir, "Combined", period, scenario, "Predictions", "Rasters")
@@ -1055,7 +1121,7 @@ with_progress({
         # Export ensemble predictions as PDF and PNG with and without occurrences
         base_file <- paste0(combined_basefile, scenario,"_", period,"_ensemble")
         
-        for (occs in list(NULL, eu_occ)){
+        for (occs in list(NULL, future_occ)){
           filename <- ifelse(is.null(occs), base_file, paste0(base_file, "_occ"))
           
           exportPDF(predictions = final_ensemble,
@@ -1096,7 +1162,7 @@ with_progress({
           # Export binarized ensemble predictions as PDF and PNG with and without occurrences 
           base_file <- paste0(combined_basefile, period,"_", scenario, "_binary",mtp_thr)
           
-          for (occs in list(NULL, eu_occ)){
+          for (occs in list(NULL, future_occ)){
             
             filename <- ifelse(is.null(occs), base_file, paste0(base_file, "_occ"))
             exportPDF(predictions = binary_map_future,
@@ -1129,23 +1195,30 @@ with_progress({
         consensus_future_climate_mean <- terra::rast(mean_future_climate_path)
         consensus_future_climate_sd <- terra::rast(sd_future_climate_path)
         
-        #reproject mean future_climate to mean habitat crs
-        consensus_future_climate_mean <- terra::project(consensus_future_climate_mean,
+        if (use_user_specific_climate_saved) {
+          future_habitat_mean <- align_continuous_raster(ensemble_habitat_mean, consensus_future_climate_mean)
+          future_habitat_sd <- align_continuous_raster(ensemble_habitat_sd, consensus_future_climate_mean)
+        } else {
+          #reproject mean future_climate to mean habitat crs
+          consensus_future_climate_mean <- terra::project(consensus_future_climate_mean,
+                                                          ensemble_habitat_mean,
+                                                          method = "bilinear")
+          consensus_future_climate_sd <- terra::project(consensus_future_climate_sd,
                                                         ensemble_habitat_mean,
                                                         method = "bilinear")
-        consensus_future_climate_sd <- terra::project(consensus_future_climate_sd,
-                                                      ensemble_habitat_mean,
-                                                      method = "bilinear")
+          future_habitat_mean <- ensemble_habitat_mean
+          future_habitat_sd <- ensemble_habitat_sd
+        }
         
         # small floor to avoid division by zero; adjust if needed
         eps <- 1e-6    
         
         # compute geometric mean
-        S <- sqrt(consensus_future_climate_mean * ensemble_habitat_mean)
+        S <- sqrt(consensus_future_climate_mean * future_habitat_mean)
         
         # compute relative SDs safely
         sd_future_climate <- consensus_future_climate_sd / (consensus_future_climate_mean + eps)
-        sd_habitat <- ensemble_habitat_sd / (ensemble_habitat_mean + eps)
+        sd_habitat <- future_habitat_sd / (future_habitat_mean + eps)
         
         # combined relative uncertainty (root-sum-of-squares)
         sd_comb <- sqrt(sd_future_climate^2 + sd_habitat^2)
@@ -1212,7 +1285,14 @@ with_progress({
     elapsed<-difftime(end_time, start_time, units="mins")
     cat("Habitat and ensemble model have been created for", species_title, "in", round(elapsed, 2), "minutes\n\n")
     
-    rm(list = setdiff(ls(), c("p", "project",  "habitatstack_file","create_folder", "custom_country_boundary_path","country_boundary", "split_df","euboundary", "habitat_stack",  "accepted_taxonkeys", "taxa_info", "key", "exportPDF", "remove_duplicates", "remove_nodata_occurrences", "favourability_from_prob", "mtp_probabilities", "occurrence_thinning_method", "mtp_probabilities", "pseudoabsence_thinning_method", "country_of_interest")))
+    rm(list = setdiff(ls(), c("p", "project",  "habitatstack_file","create_folder", 
+                              "custom_country_boundary_path","country_boundary", 
+                              "split_df","euboundary", "habitat_stack",  "accepted_taxonkeys", 
+                              "taxa_info", "key", "exportPDF", "remove_duplicates", 
+                              "remove_nodata_occurrences", "favourability_from_prob", 
+                              "mtp_probabilities", "occurrence_thinning_method", 
+                              "mtp_probabilities", "pseudoabsence_thinning_method", 
+                              "country_of_interest")))
     
     #Clean terra tempfiles
     terra::tmpFiles(remove = TRUE)

--- a/src/05_cross_validation.R
+++ b/src/05_cross_validation.R
@@ -35,23 +35,26 @@ source(here::here("src", "00_configurations.R"))
 #-------------------------- Define file paths ----------------------------------
 #-------------------------------------------------------------------------------
 #climate stack
-climate_path <- file.path("data", "external", "climate", "chelsa_current","processed", "globalclimpreds.tif")
+climate_path <- file.path("data", "external", "climate", "chelsa_current",
+                          "processed", "globalclimpreds.tif")
 
 #EU climate stack
-eu_climpreds_path <- file.path("data", "external", "climate", "chelsa_current","processed","euclimpreds.tif")
+eu_climpreds_path <- file.path("data", "external", "climate", "chelsa_current",
+                               "processed","euclimpreds.tif")
 
 #habitat stack
-habitat_path <- file.path("data", "external", "habitat", "processed", "habitat_stack.tif")
+habitat_path <- file.path("data", "external", "habitat", "processed", 
+                          "habitat_stack.tif")
 
 #Biome file path
 biome_path<-file.path("data", "external", "GIS", "official", "newRealms.shp")
-
 
 #--------------------------------------------
 #------------- Load species data ------------
 #--------------------------------------------
 #Get taxa info
-taxa_info <- read.csv2(file.path("data", "projects", project, paste0(project, "_taxa_info.csv")))
+taxa_info <- read.csv2(file.path("data", "projects", project, 
+                                 paste0(project, "_taxa_info.csv")))
 
 #Select unique taxonkeys
 accepted_taxonkeys <- unique(taxa_info$acceptedTaxonKey)
@@ -60,54 +63,39 @@ accepted_taxonkeys <- unique(taxa_info$acceptedTaxonKey)
 #--------------------------------------------
 #-----------------Load rasters---------------
 #--------------------------------------------
-#Load rasters 
-climate_stack <- terra::rast(climate_path)
+#Load rasters
 habitat_stack <- terra::rast(habitat_path)
 
 
 #--------------------------------------------
-#------------ Load euboundary  --------------
+#------ Build default validation context ----
 #--------------------------------------------
-euboundary <- load_eu_boundary(
+default_euboundary <- load_eu_boundary(
   custom_path = custom_eu_boundary_path,
   reference = habitat_stack[[1]]
 )
-euboundary_vect <- terra::vect(euboundary)
+default_euboundary_vect <- terra::vect(default_euboundary)
 
 if (is.null(custom_eu_boundary_path)) {
-  eu_climate_stack <- terra::rast(eu_climpreds_path) %>%
-    terra::project(habitat_stack[[1]])
-  
-  eu_sampling_mask <- habitat_stack[[1]]
+  default_eu_sampling_mask <- habitat_stack[[1]]
 } else {
-  eu_climate_stack <- terra::rast(eu_climpreds_path) %>%
-    terra::project(habitat_stack[[1]]) %>%
-    terra::crop(euboundary_vect) %>%
-    terra::mask(euboundary_vect)
-  
-  eu_sampling_mask <- habitat_stack[[1]] %>%
-    terra::crop(euboundary_vect) %>%
-    terra::mask(euboundary_vect)
+  default_eu_sampling_mask <- habitat_stack[[1]] %>%
+    terra::crop(default_euboundary_vect) %>%
+    terra::mask(default_euboundary_vect)
 }
 
+default_eu_sampling_cells <- terra::global(!is.na(default_eu_sampling_mask), 
+                                           "sum", na.rm = TRUE)[[1]]
 
-#-----------------------------------------------------------
-#- Sample background data once
-#-----------------------------------------------------------
-#Extract a subsample of European pixels for Boyce calculation 
-set.seed(728)
-eu_subsample <- terra::spatSample(
-  eu_sampling_mask,
-  size = boyce_background_size, 
-  method = "random", 
-  na.rm = TRUE, #Ignore NA pixels
-  as.points = TRUE)
-
-# Extract climate data at eu subsample points
-eu_climate_sub <- terra::extract(eu_climate_stack, eu_subsample, ID = FALSE, xy = FALSE)
-
-# Extract habitat data at eu subsample points
-eu_habitat_sub <- terra::extract(habitat_stack, eu_subsample, ID = FALSE, xy = FALSE)
+if (is.na(default_eu_sampling_cells) || default_eu_sampling_cells == 0) {
+  stop("No non-NA European habitat cells are available 
+       for default validation sampling.", call. = FALSE)
+}
+default_climate_stack <- NULL
+default_eu_climate_stack <- NULL
+default_eu_subsample <- NULL
+default_eu_climate_sub <- NULL
+default_eu_habitat_sub <- NULL
 
 
 #----------------------------------------------
@@ -182,7 +170,149 @@ for (i in seq_along(accepted_taxonkeys)) {
   top5_methods  <- climatemodel$top5_models
   global_presabs <- climatemodel$global_presabs
   climate_predictors <- climatemodel$selected_predictors
-  euboundary_occurrence <- euboundary %>%
+  climate_input_mode_saved <- climatemodel$climate_input_mode
+  
+  if (is.null(climate_input_mode_saved) || !nzchar(climate_input_mode_saved)) {
+    climate_input_mode_saved <- "chelsa"
+  }
+  
+  climate_manifest_path_saved <- climatemodel$climate_manifest_path
+  predictor_crs_saved <- climatemodel$predictor_crs
+  
+  if (!climate_input_mode_saved %in% c("chelsa", "user_specific")) {
+    stop(
+      "Unsupported climate input mode stored in ", basename(climate_qs_file),
+      ": ", climate_input_mode_saved, call. = FALSE
+    )
+  }
+  
+  if (climate_input_mode_saved == "user_specific") {
+    if (is.null(climate_manifest_path_saved) || !nzchar(climate_manifest_path_saved)) {
+      stop(
+        "The saved climate model metadata is missing 'climate_manifest_path'. 
+        Rerun 03_fit_climate_model.R for ", speciesName,".", call. = FALSE
+      )
+    }
+    
+    if (is.null(predictor_crs_saved) || !nzchar(predictor_crs_saved)) {
+      stop(
+        "The saved climate model metadata is missing 'predictor_crs'. 
+        Rerun 03_fit_climate_model.R for ", speciesName, ".", call. = FALSE
+      )
+    }
+    
+    climate_manifest_saved <- load_user_specific_climate_manifest(climate_manifest_path_saved)
+    climate_stack_active <- materialize_user_specific_current_stack(climate_manifest_saved)
+    
+    saved_predictor_crs <- sf::st_crs(predictor_crs_saved)
+    active_predictor_crs <- sf::st_crs(terra::crs(climate_stack_active))
+    
+    if (!isTRUE(saved_predictor_crs == active_predictor_crs)) {
+      stop(
+        "The current climate stack loaded from the saved manifest does not match 
+        the CRS stored in the climate model metadata.",
+        call. = FALSE
+      )
+    }
+    
+    euboundary_active <- load_eu_boundary(
+      custom_path = custom_eu_boundary_path,
+      reference = climate_stack_active[[1]]
+    )
+    euboundary_active_vect <- terra::vect(euboundary_active)
+    
+    eu_climate_stack_active <- climate_stack_active %>%
+      terra::crop(euboundary_active_vect) %>%
+      terra::mask(euboundary_active_vect)
+    
+    habitat_stack_on_climate <- align_continuous_raster(habitat_stack, 
+                                                        eu_climate_stack_active[[1]])
+    
+    eu_sampling_mask_active <- terra::mask(habitat_stack_on_climate[[1]], 
+                                           eu_climate_stack_active[[1]])
+    
+    eu_sampling_cells_active <- terra::global(!is.na(eu_sampling_mask_active), 
+                                              "sum", na.rm = TRUE)[[1]]
+    
+    if (is.na(eu_sampling_cells_active) || eu_sampling_cells_active == 0) {
+      
+      stop("No overlapping non-NA European cells remain after aligning habitat 
+           coverage to the user-specific climate template.",
+        call. = FALSE
+      )
+    }
+    
+    set.seed(728)
+    eu_subsample_active <- terra::spatSample(
+      eu_sampling_mask_active,
+      size = boyce_background_size,
+      method = "random",
+      na.rm = TRUE,
+      as.points = TRUE
+    )
+    
+    eu_climate_sub_active <- terra::extract(eu_climate_stack_active, 
+                                            eu_subsample_active, 
+                                            ID = FALSE, xy = FALSE)
+    eu_habitat_sub_active <- terra::extract(habitat_stack_on_climate, 
+                                            eu_subsample_active, 
+                                            ID = FALSE, xy = FALSE)
+    
+  } else {
+    
+    climate_manifest_saved <- NULL
+    
+    if (is.null(default_climate_stack)) {
+      default_climate_stack <- terra::rast(climate_path)
+    }
+    
+    if (is.null(default_eu_climate_stack)) {
+      if (is.null(custom_eu_boundary_path)) {
+        default_eu_climate_stack <- terra::rast(eu_climpreds_path) %>%
+          terra::project(habitat_stack[[1]])
+      } else {
+        default_eu_climate_stack <- terra::rast(eu_climpreds_path) %>%
+          terra::project(habitat_stack[[1]]) %>%
+          terra::crop(default_euboundary_vect) %>%
+          terra::mask(default_euboundary_vect)
+      }
+      
+      set.seed(728)
+      default_eu_subsample <- terra::spatSample(
+        default_eu_sampling_mask,
+        size = boyce_background_size,
+        method = "random",
+        na.rm = TRUE,
+        as.points = TRUE
+      )
+      
+      default_eu_climate_sub <- terra::extract(default_eu_climate_stack, 
+                                               default_eu_subsample, 
+                                               ID = FALSE, xy = FALSE)
+      default_eu_habitat_sub <- terra::extract(habitat_stack, 
+                                               default_eu_subsample, 
+                                               ID = FALSE, xy = FALSE)
+    }
+    
+    climate_stack_active <- default_climate_stack
+    euboundary_active <- default_euboundary
+    eu_climate_stack_active <- default_eu_climate_stack
+    eu_climate_sub_active <- default_eu_climate_sub
+    eu_habitat_sub_active <- default_eu_habitat_sub
+  }
+  
+  missing_climate_predictors <- setdiff(climate_predictors, 
+                                        names(climate_stack_active))
+  
+  if (length(missing_climate_predictors) > 0) {
+    stop("The current climate stack is missing predictor(s) stored in ",
+      basename(climate_qs_file), ": ",paste(missing_climate_predictors, 
+                                            collapse = ", "),
+      call. = FALSE
+    )
+  }
+  
+  euboundary_occurrence <- euboundary_active %>%
     sf::st_transform(crs = sf::st_crs(global_presabs))
   rm(climatemodel)
   
@@ -204,19 +334,19 @@ for (i in seq_along(accepted_taxonkeys)) {
   #---------------------------------------------------------
   #- Select climate rasters used in 03_fit_climate_model.R -
   #---------------------------------------------------------
-  climate_selection <- terra::subset(climate_stack,
-                                     climate_predictors[climate_predictors %in%
-                                                          names(climate_stack)])
+  climate_selection <- terra::subset(climate_stack_active, climate_predictors)
   
   
   #-----------------------------------------------------------
   #- Obtain global climate subsample values for selected predictors
   #-----------------------------------------------------------
   #Load biomes
-  wwf_eco_biome<-sf::st_read(biome_path) 
+  wwf_eco_biome <- sf::st_read(biome_path, quiet = TRUE) %>%
+    sf::st_transform(crs = get_reference_crs(climate_selection))
   
   # Keep only biome polygons that intersect at least one occurrence point
-  global_presences<-dplyr::filter(global_presabs, species==1)
+  global_presences <- dplyr::filter(global_presabs, species==1) %>%
+    sf::st_transform(crs = sf::st_crs(wwf_eco_biome))
   sf::sf_use_s2(FALSE)
   has_occurrence <- lengths(sf::st_intersects(wwf_eco_biome, global_presences)) > 0
   wwf_ecoSub1 <- wwf_eco_biome[has_occurrence, ]
@@ -251,7 +381,7 @@ for (i in seq_along(accepted_taxonkeys)) {
   #- Obtain European climate subsample values for selected predictors
   #-----------------------------------------------------------
   if(eu_climate_validation || ensemble_validation){
-    eu_points <- eu_climate_sub %>%
+    eu_points <- eu_climate_sub_active %>%
       dplyr::select(any_of(climate_predictors))%>%
       dplyr::mutate(ID = dplyr::row_number())
   }
@@ -323,7 +453,7 @@ for (i in seq_along(accepted_taxonkeys)) {
         dplyr::bind_rows(global_presabs)
       
       #Remove duplicates
-      all_presabs$cell <- terra::cellFromXY( climate_stack[[1]], 
+      all_presabs$cell <- terra::cellFromXY( climate_stack_active[[1]], 
                                              all_presabs%>%
                                                st_coordinates%>%
                                                as.data.frame()) 
@@ -397,7 +527,8 @@ for (i in seq_along(accepted_taxonkeys)) {
       dplyr::mutate(ID = dplyr::row_number())
     
     if(nrow(global_presabs_perfold)!=nrow(global_presabs)){
-      warning(nrow(global_presabs)- nrow(global_presabs_perfold)," global point(s) not assigned to a fold and removed from dataset.")
+      warning(nrow(global_presabs)- nrow(global_presabs_perfold),
+              " global point(s) not assigned to a fold and removed from dataset.")
     }
     
     
@@ -479,7 +610,9 @@ for (i in seq_along(accepted_taxonkeys)) {
       }
       
       #Add EU background data for validation of ensemble and Europe
-      if (eu_climate_validation || ensemble_validation) {datasets$eu_points  <- eu_points}
+      if (eu_climate_validation || ensemble_validation) {
+        datasets$eu_points  <- eu_points
+        }
       
       
       #---------------------------------------------------------------------
@@ -644,8 +777,11 @@ for (i in seq_along(accepted_taxonkeys)) {
   #-------------- Export results --------------
   #--------------------------------------------
   # Define directories
-  climate_validation_dir<-file.path(base_dir, "Climate", "Current", "Diagnostics", "Model_validation")
-  if(!dir.exists(climate_validation_dir)) dir.create(climate_validation_dir, recursive = TRUE, showWarnings = FALSE)
+  climate_validation_dir<-file.path(base_dir, "Climate", "Current", 
+                                    "Diagnostics", "Model_validation")
+  if(!dir.exists(climate_validation_dir)) dir.create(climate_validation_dir, 
+                                                     recursive = TRUE, 
+                                                     showWarnings = FALSE)
   
   
   # Export validation summary (mean across folds) when relevant
@@ -653,7 +789,8 @@ for (i in seq_along(accepted_taxonkeys)) {
     
     #Export per fold validation
     readr::write_csv(global_validation_climate,
-                     file.path(climate_validation_dir, paste0(speciesName, "_global_climate_validation_per_fold.csv"))) 
+                     file.path(climate_validation_dir, 
+                               paste0(speciesName, "_global_climate_validation_per_fold.csv"))) 
     
     #Export summary
     global_validation_clim_mean <- summarise_validation(df = global_validation_climate, 
@@ -752,7 +889,7 @@ for (i in seq_along(accepted_taxonkeys)) {
   #-----------------------------------------------------------
   #- Obtain habitat subsample values for selected predictors
   #-----------------------------------------------------------
-  eu_habitat_points<-eu_habitat_sub %>%
+  eu_habitat_points<-eu_habitat_sub_active %>%
     dplyr::select(any_of(habitat_predictors))%>%
     dplyr::mutate(ID = dplyr::row_number())
   

--- a/src/helper_functions.R
+++ b/src/helper_functions.R
@@ -1160,6 +1160,120 @@ load_named_raster_stack <- function(stack_rows) {
 
 
 #-----------------------------------------------------------------
+#--Build a stable cache key for current user-specific climate------
+#-----------------------------------------------------------------
+build_user_specific_climate_cache_key <- function(climate_manifest) {
+  current_rows <- climate_manifest$current_rows
+  if (is.null(current_rows) || nrow(current_rows) == 0) {
+    stop("The user-specific climate manifest does not contain current/current rows.", call. = FALSE)
+  }
+  
+  raster_info <- file.info(current_rows$file_path)
+  if (any(is.na(raster_info$size)) || any(is.na(raster_info$mtime))) {
+    stop("One or more current climate rasters could not be inspected for caching.", call. = FALSE)
+  }
+  
+  key_lines <- c(
+    "cache_scope=current_rows_v2",
+    paste("n_current_layers", nrow(current_rows), sep = "="),
+    paste(
+      current_rows$var_name,
+      current_rows$file_path,
+      raster_info$size,
+      format(raster_info$mtime, tz = "UTC", usetz = TRUE),
+      sep = "|"
+    )
+  )
+  
+  key_file <- tempfile(pattern = "user_specific_climate_key_", fileext = ".txt")
+  on.exit(unlink(key_file), add = TRUE)
+  writeLines(key_lines, key_file, useBytes = TRUE)
+  unname(tools::md5sum(key_file))
+}
+
+
+#-----------------------------------------------------------------
+#--Materialize current user-specific climate stack to disk--------
+#-----------------------------------------------------------------
+materialize_user_specific_current_stack <- function(climate_manifest,
+                                                    cache_dir = file.path("data", "external", "climate", "chelsa_current", "processed"),
+                                                    cache_prefix = "user_specific_current_stack") {
+  cache_dir <- resolve_input_path(cache_dir)
+  if (!dir.exists(cache_dir)) {
+    dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+  }
+  
+  cache_key <- build_user_specific_climate_cache_key(climate_manifest)
+  cache_file <- file.path(cache_dir, paste0(cache_prefix, "_", cache_key, ".tif"))
+  expected_names <- as.character(climate_manifest$current_rows$var_name)
+  
+  if (file.exists(cache_file)) {
+    cached_stack <- tryCatch(terra::rast(cache_file), error = function(e) NULL)
+    
+    if (!is.null(cached_stack) &&
+        terra::nlyr(cached_stack) == length(expected_names) &&
+        identical(names(cached_stack), expected_names)) {
+      return(cached_stack)
+    }
+  }
+  
+  stack <- load_named_raster_stack(climate_manifest$current_rows)
+  stack <- terra::mask(stack, anyNA(stack), maskvalue = 1)
+  
+  terra::writeRaster(
+    stack,
+    filename = cache_file,
+    overwrite = TRUE,
+    wopt = list(gdal = c("COMPRESS=LZW"))
+  )
+  
+  cached_stack <- terra::rast(cache_file)
+  
+  if (terra::nlyr(cached_stack) != length(expected_names) ||
+      !identical(names(cached_stack), expected_names)) {
+    stop(
+      "The cached user-specific climate stack does not match the expected predictor names.",
+      call. = FALSE
+    )
+  }
+  
+  cached_stack
+}
+
+
+#-----------------------------------------------------------------
+#--Align a continuous raster to a template raster------------------
+#-----------------------------------------------------------------
+align_continuous_raster <- function(raster, template, method = "bilinear") {
+  if (!inherits(raster, "SpatRaster")) {
+    stop("'raster' must be a terra SpatRaster.", call. = FALSE)
+  }
+  
+  if (!inherits(template, "SpatRaster")) {
+    stop("'template' must be a terra SpatRaster.", call. = FALSE)
+  }
+  
+  if (!nzchar(terra::crs(raster))) {
+    stop("The raster to align does not have a defined CRS.", call. = FALSE)
+  }
+  
+  if (!nzchar(terra::crs(template))) {
+    stop("The template raster does not have a defined CRS.", call. = FALSE)
+  }
+  
+  if (!isTRUE(terra::same.crs(raster, template))) {
+    return(terra::project(raster, template, method = method))
+  }
+  
+  if (!isTRUE(terra::compareGeom(raster, template, lyrs = FALSE, stopOnError = FALSE))) {
+    return(terra::resample(raster, template, method = method))
+  }
+  
+  raster
+}
+
+
+#-----------------------------------------------------------------
 #--Create an approximately 5 km template for pseudoabsences-------
 #-----------------------------------------------------------------
 create_pseudoabsence_template <- function(raster_layer, target_resolution_m = 5000) {


### PR DESCRIPTION

Carries user-specific climate data through the workflow so that downstream habitat modeling (script 04) and cross-validation (script 05) can use the same climate stack used during climate-model fitting.

**Summary:**
- Stores the "climate input mode", manifest path, predictor CRS, and selected predictors in climate model outputs in qs output files (metadata for carrying forward the workflow structure).

- Materializes/cache-loads user-specific current climate stacks. Implements several helper functions to do this (implemented with assistance from ChatGPT to improve the functionality, design and for debugging). Requires some attentive checking;

- Aligns habitat rasters to user-specific climate templates when combining outputs (if CRS differ; climate data in this case is considered the reference to potentially minimize reprojections since we have many climate layers for different scenarios vs few habitat layers; default is static; helper implemented for this too).

- Updates cross-validation to load the saved climate manifest and validate against the correct CRS/grid.

- Creates Europe-level climate predictions for user-supplied climate inputs. **Periods and scenarios remain hard-coded to the ones considered in the original/default wiSDM workflow.**

- Saved model metadata compatibility with older CHELSA-based outputs.

- Raster alignment/resampling choices between habitat and climate stacks.

- Cross-validation behavior differs depending on whether the workflow runs in default CHELSA mode or with user-specific climate data. _Code reviewing should verify that the underlying logic and execution flow remain consistent across both modes._
